### PR TITLE
Fix inability to disable prefs with True default

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -81,12 +81,7 @@ class Settings:
             if key in syntax_settings:
                 return syntax_settings[key]
 
-        # check global settings
-        if self.s.has(key) and self.s.get(key):
-            return self.s.get(key)
-
-        # fallback
-        return default
+        return self.s.get(key, default)
 
     def set(self, key, value):
         syntax = self.syntax()


### PR DESCRIPTION
The use case for this is setting `auto_advance` to `False`.