### PR TITLE
fix typos/grammar in install message

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -1,3 +1,3 @@
-Thank you for begin intrested in SendCode.
+Thank you for installing SendCode.
 
 Please visit https://github.com/randy3k/SendCode for the details.


### PR DESCRIPTION
A little bit googling
https://www.google.com/search?q=thank+you+for+begin+interested
https://www.google.com/search?q=thank+you+for+installing

It seems that `thank you for installing` is more common.