### PR TITLE
Improve Julia begin/let/quote block

### DIFF
--- a/code_getter/getter.py
+++ b/code_getter/getter.py
@@ -254,8 +254,8 @@ class JuliaCodeGetter(CodeGetter):
         lastrow = view.rowcol(view.size())[0]
 
         keywords = [
-            "function", "macro", "if", "for", "while", "let", "quote",
-            "try", "module", "abstruct", "type", "struct", "immutable", "mutable"
+            "function", "macro", "if", "for", "while", "try", "module",
+            "abstruct", "type", "struct", "immutable", "mutable"
         ]
 
         if re.match(r"^(#\s%%|#%%)", thiscmd):
@@ -273,7 +273,7 @@ class JuliaCodeGetter(CodeGetter):
                 s = sublime.Region(s.begin(), prevline.end())
         elif (re.match(r"\s*(?:{})".format("|".join(keywords)), thiscmd) and
                 not re.match(r".*end\s*$", thiscmd)) or \
-                (re.match(r".*begin\s*$", thiscmd)):
+                (re.match(r".*(?:begin|let|quote)\s*", thiscmd)):
             indentation = re.match(r"^(\s*)", thiscmd).group(1)
             endline = view.find("^" + indentation + "end", s.begin())
             s = sublime.Region(s.begin(), view.line(endline.end()).end())


### PR DESCRIPTION
We can put things before the `begin`.
```julia
x = begin
        3.14
end
```
However, it does not work for `let` and `quote`.

The change allows `let` and `quote` works same as `begin`. Also, codes can be put right behind the keywords, as `let` needs it.

```julia
y = let t = 3, s = 5
    t + s
end
```
```julia
ex = quote
           x = 1
           y = 2
           x + y
end
```