### PR TITLE
Ignore empty lines

### DIFF
--- a/code_getter/getter.py
+++ b/code_getter/getter.py
@@ -90,8 +90,10 @@ class CodeGetter:
                     view.sel().subtract(original_s)
                     self.advance(s)
                     moved = True
-
-            cmd += self.substr(s) + '\n'
+            
+            subs_cmd = self.substr(s)
+            if subs_cmd:
+                cmd += subs_cmd + '\n'
 
         if moved:
             view.show(view.sel())

--- a/send_code.py
+++ b/send_code.py
@@ -25,5 +25,6 @@ class SendCodeCommand(sublime_plugin.TextCommand):
             code = getter.resolve(code)
         else:
             code = getter.get_code()
-
-        sublime.set_timeout_async(lambda: sender.send_text(code))
+        
+        if code:
+            sublime.set_timeout_async(lambda: sender.send_text(code))


### PR DESCRIPTION
when running through a file using "ctrl+enter" don't send empty lines.

In essence ignores "cmd" of zero length in getter.py and also doesn't send "code" of zero length in send_code.py