### PR TITLE
Setting for selecting `linux-terminal` windows by WM_NAME (window title)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If you have multiple instances of the same terminal emulator running (e.g. one `
 }
 ```
 
-It is not recommended to use the `linux_window_name` setting unless you specify a permanent window name when running your terminal emulator; by default, window names may change frequently, making this setting useless. Note that `linux_window_name` is only meaningful when in a settings block where `prog` is set to `linux-terminal`.
+It is not recommended to use the `linux_window_name` setting unless you specify a permanent window name when running your terminal emulator; by default, window names may change frequently, which makes this setting unreliable (although you can use a regular expression in `linux_window_name` to try to catch these windows). Note that `linux_window_name` is only meaningful when in a settings block where `prog` is set to `linux-terminal`.
 
 ### Block expansion
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ Project-wise settings could also be specified in `sublime-project` as
 }
 ```
 
+#### Enabling selection by window name/title (WM_NAME) for linux-terminal
+
+If you have multiple instances of the same terminal emulator running (e.g. one `alacritty` window for R, one for IPython, etc.), you may want to want to send code to a terminal with a specific name/title (e.g. so `python` code is sent to the window named `My Special IPython` but 'julia' code is sent to `My Julia`). If you force a permanent window name when running your terminal emulator (e.g. `$ alacritty -t "My Special IPython"`), you can place this name in a `window_name` SendCode setting. SendCode will then first try to find a window with the corresponding `WM_NAME` *before* using the `WM_CLASS` specified by the `linux_terminal` global setting. 
+
+It is not recommended to use the `window_name` setting unless you specify a permanent window name when running your terminal emulator; by default, window names may change frequently, making this setting useless. Note that `window_name` is only meaningful when in a settings block where `prog` is set to `linux-terminal`.
 
 ### Block expansion
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,25 @@ Project-wise settings could also be specified in `sublime-project` as
 
 #### Enabling selection by window name/title (WM_NAME) for linux-terminal
 
-If you have multiple instances of the same terminal emulator running (e.g. one `alacritty` window for R, one for IPython, etc.), you may want to want to send code to a terminal with a specific name/title (e.g. so `python` code is sent to the window named `My Special IPython` but 'julia' code is sent to `My Julia`). If you force a permanent window name when running your terminal emulator (e.g. `$ alacritty -t "My Special IPython"`), you can place this name in a `linux_window_name` SendCode setting. SendCode will then first try to find a window with the corresponding `WM_NAME` *before* using the `WM_CLASS` specified by the `linux_terminal` global setting. 
+If you have multiple instances of the same terminal emulator running (e.g. one `alacritty` window for R, one for IPython, etc.), you may want to want to send code to a terminal with a specific name/title (e.g. so `python` code is sent to the window named `My Special IPython` but 'julia' code is sent to `My Julia`). If you force a permanent window name when running your terminal emulator (e.g. `$ alacritty -t "My Special IPython"`), you can place this name in a `linux_window_name` SendCode setting. SendCode will then first try to find a window with the corresponding `WM_NAME` *before* using the `WM_CLASS` specified by the `linux_terminal` global setting:
+
+```js
+{
+    "linux_terminal": "alacritty",
+    "prog": "linux-terminal",
+
+    // First try to send Python & Julia code to the named windows, respectively
+    "python" : {
+        "linux_window_name": "My Special IPython",
+        "bracketed_paste_mode": true,
+    }, 
+    "julia" : {
+        "linux_window_name": "My Julia",
+        "bracketed_paste_mode": true,
+    }
+    // Other code behaves as usual (e.g. R gets sent to the last alacritty window)
+}
+```
 
 It is not recommended to use the `linux_window_name` setting unless you specify a permanent window name when running your terminal emulator; by default, window names may change frequently, making this setting useless. Note that `linux_window_name` is only meaningful when in a settings block where `prog` is set to `linux-terminal`.
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Project-wise settings could also be specified in `sublime-project` as
 
 #### Enabling selection by window name/title (WM_NAME) for linux-terminal
 
-If you have multiple instances of the same terminal emulator running (e.g. one `alacritty` window for R, one for IPython, etc.), you may want to want to send code to a terminal with a specific name/title (e.g. so `python` code is sent to the window named `My Special IPython` but 'julia' code is sent to `My Julia`). If you force a permanent window name when running your terminal emulator (e.g. `$ alacritty -t "My Special IPython"`), you can place this name in a `linux_window_name` SendCode setting. SendCode will then first try to find a window with the corresponding `WM_NAME` *before* using the `WM_CLASS` specified by the `linux_terminal` global setting:
+If you have multiple instances of the same terminal emulator running (e.g. one `alacritty` window for R, one for IPython, etc.), you may want to want to send code to a terminal with a specific name/title (e.g. so `python` code is sent to the window named `My Special IPython` but 'julia' code is sent to `My Julia`). If you force a permanent window name when running your terminal emulator (e.g. `$ alacritty -t "My Special IPython"`), you can place this name in a `linux_window_name` SendCode setting. SendCode will then first try to find a window with the corresponding `WM_NAME` *before* using the `WM_CLASS` specified by the `linux_terminal` global setting. A minimal example is:
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ Project-wise settings could also be specified in `sublime-project` as
 
 #### Enabling selection by window name/title (WM_NAME) for linux-terminal
 
-If you have multiple instances of the same terminal emulator running (e.g. one `alacritty` window for R, one for IPython, etc.), you may want to want to send code to a terminal with a specific name/title (e.g. so `python` code is sent to the window named `My Special IPython` but 'julia' code is sent to `My Julia`). If you force a permanent window name when running your terminal emulator (e.g. `$ alacritty -t "My Special IPython"`), you can place this name in a `window_name` SendCode setting. SendCode will then first try to find a window with the corresponding `WM_NAME` *before* using the `WM_CLASS` specified by the `linux_terminal` global setting. 
+If you have multiple instances of the same terminal emulator running (e.g. one `alacritty` window for R, one for IPython, etc.), you may want to want to send code to a terminal with a specific name/title (e.g. so `python` code is sent to the window named `My Special IPython` but 'julia' code is sent to `My Julia`). If you force a permanent window name when running your terminal emulator (e.g. `$ alacritty -t "My Special IPython"`), you can place this name in a `linux_window_name` SendCode setting. SendCode will then first try to find a window with the corresponding `WM_NAME` *before* using the `WM_CLASS` specified by the `linux_terminal` global setting. 
 
-It is not recommended to use the `window_name` setting unless you specify a permanent window name when running your terminal emulator; by default, window names may change frequently, making this setting useless. Note that `window_name` is only meaningful when in a settings block where `prog` is set to `linux-terminal`.
+It is not recommended to use the `linux_window_name` setting unless you specify a permanent window name when running your terminal emulator; by default, window names may change frequently, making this setting useless. Note that `linux_window_name` is only meaningful when in a settings block where `prog` is set to `linux-terminal`.
 
 ### Block expansion
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Project-wise settings could also be specified in `sublime-project` as
 
 #### Enabling selection by window name/title (WM_NAME) for linux-terminal
 
-If you have multiple instances of the same terminal emulator running (e.g. one `alacritty` window for R, one for IPython, etc.), you may want to want to send code to a terminal with a specific name/title (e.g. so `python` code is sent to the window named `My Special IPython` but 'julia' code is sent to `My Julia`). If you force a permanent window name when running your terminal emulator (e.g. `$ alacritty -t "My Special IPython"`), you can place this name in a `linux_window_name` SendCode setting. SendCode will then first try to find a window with the corresponding `WM_NAME` *before* using the `WM_CLASS` specified by the `linux_terminal` global setting. A minimal example is:
+If you have multiple instances of the same terminal emulator running (e.g. one `alacritty` window for R, one for IPython, etc.), you may want to want to send code to a terminal with a specific name/title (e.g. so `python` code is sent to the window named `My Special IPython` but `julia` code is sent to `My Julia`). If you force a permanent window name when running your terminal emulator (e.g. `$ alacritty -t "My Special IPython"`), you can place this name in a `linux_window_name` SendCode setting. SendCode will then first try to find a window with the corresponding `WM_NAME` *before* using the `WM_CLASS` specified by the `linux_terminal` global setting. A minimal example is:
 
 ```js
 {

--- a/code_sender/linux/__init__.py
+++ b/code_sender/linux/__init__.py
@@ -39,13 +39,13 @@ if plat == "linux":
         else:
             xdotool("windowfocus", sublime_id)
 
-    def get_linux_wids(window_name, linux_terminal):
+    def get_linux_wids(linux_window_name, linux_terminal):
         try:
-            wids = xdotool("search", "--onlyvisible", "--name", window_name)
+            wids = xdotool("search", "--onlyvisible", "--name", linux_window_name)
             return wids
         except CalledProcessError:
             sublime.status_message("{} (WM_NAME) not found; trying {} (WM_CLASS)"
-                                   .format(window_name, linux_terminal))
+                                   .format(linux_window_name, linux_terminal))
         except TypeError:
             # We get here if window_name is None, meaning we should just look at WM_CLASS
             pass

--- a/code_sender/linux/__init__.py
+++ b/code_sender/linux/__init__.py
@@ -42,18 +42,15 @@ if plat == "linux":
             xdotool("windowfocus", sublime_id)
 
     def get_linux_wids(linux_window_name, linux_terminal):
-        try:
-            wids = xdotool("search", "--onlyvisible", "--name", linux_window_name)
-            return wids
-        except CalledProcessError:
-            sublime.status_message("{} (WM_NAME) not found; trying {} (WM_CLASS)"
-                                   .format(linux_window_name, linux_terminal))
-        except TypeError:
-            # We get here if linux_window_name is None, meaning we should just look at
-            # WM_CLASS (the default behavior if this optional key is not in the settings)
-            pass
-
-        wids = xdotool("search", "--onlyvisible", "--class", linux_terminal)
+        if linux_window_name:
+            try:
+                wids = xdotool("search", "--onlyvisible", "--name", linux_window_name)
+            except CalledProcessError:
+                sublime.status_message("{} (WM_NAME) not found; trying {} (WM_CLASS)"
+                                       .format(linux_window_name, linux_terminal))
+                wids = xdotool("search", "--onlyvisible", "--class", linux_terminal)
+        else:
+            wids = xdotool("search", "--onlyvisible", "--class", linux_terminal)
 
         if not wids:
             raise Exception("{} not found.".format(linux_terminal))

--- a/code_sender/linux/__init__.py
+++ b/code_sender/linux/__init__.py
@@ -47,7 +47,7 @@ if plat == "linux":
             sublime.status_message("{} (WM_NAME) not found; trying {} (WM_CLASS)"
                                    .format(window_name, linux_terminal))
         except TypeError:
-            # We get here if window_name is None
+            # We get here if window_name is None, meaning we should just look at WM_CLASS
             pass
 
         wids = xdotool("search", "--onlyvisible", "--class", linux_terminal)
@@ -57,10 +57,9 @@ if plat == "linux":
 
         return wids
 
-
 else:
-    def get_linux_wids(cmd):
+    def send_to_linux_terminal(cmd):
         pass
 
-    def send_to_linux_terminal(cmd):
+    def get_linux_wids(cmd):
         pass

--- a/code_sender/linux/__init__.py
+++ b/code_sender/linux/__init__.py
@@ -9,7 +9,9 @@ plat = sublime.platform()
 if plat == "linux":
     from ..xdotool import xdotool
 
-    def send_to_linux_terminal(wids, cmd_list):
+    def send_to_linux_terminal(linux_window_name, linux_terminal, cmd_list):
+        wids = get_linux_wids(linux_window_name, linux_terminal)
+
         wid = wids.decode("utf-8").strip().split("\n")[-1]
 
         if isinstance(cmd_list, str):
@@ -47,7 +49,8 @@ if plat == "linux":
             sublime.status_message("{} (WM_NAME) not found; trying {} (WM_CLASS)"
                                    .format(linux_window_name, linux_terminal))
         except TypeError:
-            # We get here if window_name is None, meaning we should just look at WM_CLASS
+            # We get here if linux_window_name is None, meaning we should just look at
+            # WM_CLASS (the default behavior if this optional key is not in the settings)
             pass
 
         wids = xdotool("search", "--onlyvisible", "--class", linux_terminal)

--- a/code_sender/sender.py
+++ b/code_sender/sender.py
@@ -57,9 +57,9 @@ class CodeSender:
         send_to_cmder(cmd, conemuc, bracketed=self.bracketed_paste_mode)
 
     def send_to_linux_terminal(self, cmd):
-        window_name = self.settings.get("window_name")
+        linux_window_name = self.settings.get("linux_window_name")
         linux_terminal = self.settings.get("linux_terminal")
-        wids = get_linux_wids(window_name, linux_terminal)
+        wids = get_linux_wids(linux_window_name, linux_terminal)
         send_to_linux_terminal(wids, cmd)
 
     def send_to_tmux(self, cmd):

--- a/code_sender/sender.py
+++ b/code_sender/sender.py
@@ -8,7 +8,7 @@ from .iterm import send_to_iterm
 from .r import send_to_r
 from .rstudio import send_to_rstudio
 from .conemu import send_to_conemu, send_to_cmder
-from .linux import send_to_linux_terminal
+from .linux import send_to_linux_terminal, get_linux_wids
 from .tmux import send_to_tmux
 from .screen import send_to_screen
 from .chrome import send_to_chrome_jupyter, send_to_chrome_rstudio
@@ -57,8 +57,10 @@ class CodeSender:
         send_to_cmder(cmd, conemuc, bracketed=self.bracketed_paste_mode)
 
     def send_to_linux_terminal(self, cmd):
+        window_name = self.settings.get("window_name")
         linux_terminal = self.settings.get("linux_terminal")
-        send_to_linux_terminal(linux_terminal, cmd)
+        wids = get_linux_wids(window_name, linux_terminal)
+        send_to_linux_terminal(wids, cmd)
 
     def send_to_tmux(self, cmd):
         tmux = self.settings.get("tmux", "tmux")
@@ -225,15 +227,17 @@ class PythonCodeSender(CodeSender):
                 send_to_cmder(cmd, conemuc)
 
     def send_to_linux_terminal(self, cmd):
+        window_name = self.settings.get("window_name")
         linux_terminal = self.settings.get("linux_terminal")
+        wids = get_linux_wids(window_name, linux_terminal)
 
         if len(re.findall("\n", cmd)) > 0:
             if self.bracketed_paste_mode:
-                send_to_linux_terminal(linux_terminal, [cmd, ""])
+                send_to_linux_terminal(wids, [cmd, ""])
             else:
-                send_to_linux_terminal(linux_terminal, [r"%cpaste -q", cmd, "--"])
+                send_to_linux_terminal(wids, [r"%cpaste -q", cmd, "--"])
         else:
-            send_to_linux_terminal(linux_terminal, cmd)
+            send_to_linux_terminal(wids, cmd)
 
     def send_to_tmux(self, cmd):
         tmux = self.settings.get("tmux", "tmux")

--- a/code_sender/sender.py
+++ b/code_sender/sender.py
@@ -59,8 +59,7 @@ class CodeSender:
     def send_to_linux_terminal(self, cmd):
         linux_window_name = self.settings.get("linux_window_name")
         linux_terminal = self.settings.get("linux_terminal")
-        wids = get_linux_wids(linux_window_name, linux_terminal)
-        send_to_linux_terminal(wids, cmd)
+        send_to_linux_terminal(linux_window_name, linux_terminal, cmd)
 
     def send_to_tmux(self, cmd):
         tmux = self.settings.get("tmux", "tmux")
@@ -227,17 +226,17 @@ class PythonCodeSender(CodeSender):
                 send_to_cmder(cmd, conemuc)
 
     def send_to_linux_terminal(self, cmd):
-        window_name = self.settings.get("window_name")
+        linux_window_name = self.settings.get("linux_window_name")
         linux_terminal = self.settings.get("linux_terminal")
-        wids = get_linux_wids(window_name, linux_terminal)
 
         if len(re.findall("\n", cmd)) > 0:
             if self.bracketed_paste_mode:
-                send_to_linux_terminal(wids, [cmd, ""])
+                send_to_linux_terminal(linux_window_name, linux_terminal, [cmd, ""])
             else:
-                send_to_linux_terminal(wids, [r"%cpaste -q", cmd, "--"])
+                send_to_linux_terminal(linux_window_name, linux_terminal,
+                                       [r"%cpaste -q", cmd, "--"])
         else:
-            send_to_linux_terminal(wids, cmd)
+            send_to_linux_terminal(linux_window_name, linux_terminal, cmd)
 
     def send_to_tmux(self, cmd):
         tmux = self.settings.get("tmux", "tmux")

--- a/code_sender/sender.py
+++ b/code_sender/sender.py
@@ -8,7 +8,7 @@ from .iterm import send_to_iterm
 from .r import send_to_r
 from .rstudio import send_to_rstudio
 from .conemu import send_to_conemu, send_to_cmder
-from .linux import send_to_linux_terminal, get_linux_wids
+from .linux import send_to_linux_terminal
 from .tmux import send_to_tmux
 from .screen import send_to_screen
 from .chrome import send_to_chrome_jupyter, send_to_chrome_rstudio


### PR DESCRIPTION
As I proposed in #163, this pull request adds an optional setting `window_name` that alters the behavior of the `linux-terminal` prog setting. If set, `xdotool` will attempt to find a window with a `WM_NAME` that matches the `window_name` pattern. If unsuccessful, it will fall back to the default behavior (i.e., just send code to the latest window whose `WM_CLASS` matches the value of `linux_terminal`). This pull request also contains a proposed subsection in the readme describing the use-case of `window_name` and giving an example configuration.

The anticipated user of this setting is someone who simultaneously uses multiple windows that contain multiple REPLs--for example, a researcher or analyst working on a project with a mixed codebase whose workflow consists of running Python code before running some R code to analyze the results. This pull should be particularly useful for users who configure their workspace[s] with saved layouts (in which assigning immutable names to windows is very common). Prior to this pull request, the workaround that I personally used to emulate this behavior was to run different REPLs in different terminal emulators (radian in Terminator, ipython in kitty, etc.).

This is obviously my first pull request for SendCode, so sorry for any silly mistakes or assumptions!